### PR TITLE
Changed repo to razor-provisioning/razor

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ The default is `"npm"` (using `$PATH` lookup).
 
 The Git URL for the Razor codebase.
 
-The default is `"https://github.com/puppetlabs/Razor.git"`.
+The default is `"https://github.com/razor-provisioning/Razor.git"`.
 
 ### <a name="attributes-app-git-rev"></a> app/git_rev
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,7 +81,7 @@ default['razor']['install_path']          = '/opt/razor'
 default['razor']['bundle_cmd']  = 'bundle'
 default['razor']['npm_cmd']     = 'npm'
 
-default['razor']['app']['git_url']  = 'https://github.com/puppetlabs/Razor.git'
+default['razor']['app']['git_url']  = 'https://github.com/razor-provisioning/Razor.git'
 default['razor']['app']['git_rev']  = '0.9.0'
 
 default['razor']['rubygems_source']['version'] = src_version = "1.8.24"


### PR DESCRIPTION
This addresses issue #. It is intended as a short term-ish fix so this cookbook continues functioning whilst either the PuppetLabs rewrite stabilizes, or something else happens. The new repo is located at https://github.com/razor-provisioning/Razor
